### PR TITLE
Cursor restore fix

### DIFF
--- a/app/js/App.vue
+++ b/app/js/App.vue
@@ -224,8 +224,10 @@
 			},
 			changeFontSize(fontSize) {
 				if (fontSize) {
+					const lineHeight = this.getViewerForTab(this.currentTab).changeFontSize(fontSize, 0);
+					
 					this.$refs.fileViewer.forEach(fileViewer => {
-						fileViewer.changeFontSize(fontSize);
+						fileViewer.changeFontSize(fontSize, lineHeight);
 					});
 				}
 			},


### PR DESCRIPTION
Problem: When the filters were altered, the viewer automatically scrolled to the top of the documents. The previously selected line and the cursor would be lost in the process.

Solution: 
The timestamp regex was changed to properly select the timestamps (previously returning 0). 
The getRowOffset(row) started using the lineHeight as suggested in the previous comments. 
A new function getTimestampFromParentLine(row) was created to get the timestamp of a given row for multi-line log entries.